### PR TITLE
bug fixed that prevents window from loading on mac

### DIFF
--- a/bean_gui/windows.py
+++ b/bean_gui/windows.py
@@ -50,7 +50,6 @@ class Window:
         '''
 
         self.root=tk.Tk()
-        self.root.overrideredirect(True)
         self.winsize=current_size(self.root)
         self.w_size=window_size(self.root,size)
         title_bar = ttk.Frame(self.root)

--- a/bean_gui/windows.py
+++ b/bean_gui/windows.py
@@ -50,6 +50,7 @@ class Window:
         '''
 
         self.root=tk.Tk()
+        #self.root.overrideredirect(True)
         self.winsize=current_size(self.root)
         self.w_size=window_size(self.root,size)
         title_bar = ttk.Frame(self.root)


### PR DESCRIPTION
The line
```
self.root.overrideredirect(True)
```
prevents the app window from loading on mac, breaking the entire application.

Removing this line fixes the issue.

This branch has been tested on macOS Big Sur version 11.2